### PR TITLE
Fixing a typo in a `daemonize` template comment and making it more descriptive

### DIFF
--- a/daemonize.nim
+++ b/daemonize.nim
@@ -24,7 +24,7 @@ template daemonize*(pidfile, si, so, se, cd: string,body: typed): void =
   ## pidfile: path to file where pid will be stored
   ## si: standard input for daemonzied process
   ## so: standard output for daemonzied process
-  ## se: standard ouput for daemonzied process
+  ## se: standard error output for daemonzied process
   ## cd: directory to switch to, nil or empty to stay
 
   if fileExists(pidfile):


### PR DESCRIPTION
Fixing comment in `daemonize` template, fixing a typo and making text describing `se` parameter more descriptive